### PR TITLE
Improve TOC structure and width for register visibility in Technical Reference Manual

### DIFF
--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -135,7 +135,7 @@
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);
-  --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
+  --toc-width--widescreen: calc(576 / var(--rem-base) * 1rem);
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
   --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
   /* stacking */

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -1,3 +1,3 @@
-<aside class="toc sidebar" data-title="{{{or page.attributes.toctitle 'Contents'}}}" data-levels="{{{or page.attributes.toclevels 2}}}">
+<aside class="toc sidebar" data-title="{{{or page.attributes.toctitle 'Contents'}}}" data-levels="{{{or page.attributes.toclevels 3}}}">
   <div class="toc-menu"></div>
 </aside>


### PR DESCRIPTION
I propose a format update for the documentation site, specifically targeting the Technical Reference Manual.

1. Increase the right-hand TOC (Contents) depth from level 2 to level 3
2. Expand the width of the right-hand TOC panel to 576 pixels

These changes are intended to make it easier for software and logic engineers to access register information.
If you agree with this change, please feel free to merge it.