### PR TITLE
github: workflow: Use `npm install` instead of `npm ci`

### DIFF
--- a/.github/workflows/release-antora-ui.yml
+++ b/.github/workflows/release-antora-ui.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build Antora UI bundle
         run: npx gulp bundle


### PR DESCRIPTION
We've removed the lock file but forgot about `npm ci`, which requires `package-lock.json`. Use `npm install` to install packages instead of `npm ci`.