### PR TITLE
github: workflows: Split Antora UI build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,8 @@
+name: Build Antora UI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    uses: ./.github/workflows/reuse-build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release Antora UI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    uses: ./.github/workflows/reuse-build.yml
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download UI bundle artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: ui-bundle
+
+      - name: Create GitHub Release and upload asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ui-bundle.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reuse-build.yml
+++ b/.github/workflows/reuse-build.yml
@@ -1,12 +1,10 @@
-name: Build & Release Antora UI
+name: Build Antora UI (reusable)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
 
 jobs:
-  build-and-release:
+  build-reusable:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,9 +22,9 @@ jobs:
       - name: Build Antora UI bundle
         run: npx gulp bundle
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload UI bundle artifact
+        uses: actions/upload-artifact@v6
         with:
-          files: build/ui-bundle.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: ui-bundle
+          path: build/ui-bundle.zip
+          if-no-files-found: error


### PR DESCRIPTION
Add a pull_request workflow that calls the reusable Antora UI build. Add a tag-triggered release workflow that depends on the build, downloads the built ui-bundle artifact, and publishes it as a GitHub Release asset:(with contents:write permission).

Refactor the old tag workflow into a reusable workflow (workflow_call): remove the release step and upload build/ui-bundle.zip as an artifact.