### PR TITLE
Add image lightbox for documentation pages

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -484,14 +484,57 @@
 .doc .image > img,
 .doc .image > object,
 .doc .image > svg {
+  background-color: var(--image-transparent-background-color);
+  background-image: var(--image-transparent-background);
+  background-position: 0 0, 0.5rem 0.5rem;
+  background-size: var(--image-transparent-background-size) var(--image-transparent-background-size);
   display: inline-block;
   height: auto;
   max-width: 100%;
   vertical-align: middle;
 }
 
+.doc .imageblock img,
+.doc .image > img,
+.doc .image a > img {
+  cursor: zoom-in;
+}
+
 .doc .image:not(.left):not(.right) > img {
   margin-top: -0.2em;
+}
+
+.image-lightbox {
+  align-items: center;
+  background: rgba(0, 0, 0, 0.88);
+  cursor: zoom-out;
+  display: none;
+  inset: 0;
+  justify-content: center;
+  padding: 2rem;
+  position: fixed;
+  z-index: 1000;
+}
+
+.image-lightbox.is-active {
+  display: flex;
+}
+
+.image-lightbox img {
+  background-color: var(--image-transparent-background-color);
+  background-image: var(--image-transparent-background);
+  background-position: 0 0, 0.5rem 0.5rem;
+  background-size: var(--image-transparent-background-size) var(--image-transparent-background-size);
+  box-shadow: 0 1.25rem 3rem rgba(0, 0, 0, 0.35);
+  cursor: auto;
+  max-height: 100%;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+html.is-clipped--image-lightbox,
+html.is-clipped--image-lightbox body {
+  overflow: hidden;
 }
 
 .doc .videoblock iframe,

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -506,18 +506,28 @@
 
 .image-lightbox {
   align-items: center;
-  background: rgba(0, 0, 0, 0.88);
+  background: rgba(16, 18, 22, 0.28);
+  -webkit-backdrop-filter: blur(0);
+  backdrop-filter: blur(0);
   cursor: zoom-out;
-  display: none;
+  display: flex;
   inset: 0;
   justify-content: center;
+  opacity: 0;
   padding: 2rem;
+  pointer-events: none;
   position: fixed;
+  transition: opacity 240ms ease, visibility 240ms ease, -webkit-backdrop-filter 360ms ease, backdrop-filter 360ms ease;
+  visibility: hidden;
   z-index: 1000;
 }
 
 .image-lightbox.is-active {
-  display: flex;
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
 }
 
 .image-lightbox img {
@@ -530,6 +540,7 @@
   max-height: 100%;
   max-width: 100%;
   object-fit: contain;
+  transform-origin: center center;
 }
 
 html.is-clipped--image-lightbox,

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -79,6 +79,9 @@
   --doc-line-height: 1.6;
   --doc-margin: 0 auto;
   --doc-margin--desktop: 0 2rem;
+  --image-transparent-background: none;
+  --image-transparent-background-color: #fff;
+  --image-transparent-background-size: auto;
   --heading-font-color: var(--color-jet-80);
   --heading-font-weight: normal;
   --alt-heading-font-weight: var(--body-font-weight-bold);

--- a/src/js/07-image-lightbox.js
+++ b/src/js/07-image-lightbox.js
@@ -14,6 +14,9 @@
   var lightbox = document.createElement('div')
   lightbox.className = 'image-lightbox'
   lightbox.setAttribute('aria-hidden', 'true')
+  var closeTimer
+  var activeSourceImage
+  var animationDuration = 360
 
   var lightboxImage = document.createElement('img')
   lightboxImage.alt = ''
@@ -36,17 +39,66 @@
   })
 
   function openLightbox (img) {
+    window.clearTimeout(closeTimer)
+    activeSourceImage = img
     lightboxImage.src = img.currentSrc || img.src
     lightboxImage.alt = img.alt || ''
     lightbox.classList.add('is-active')
     lightbox.setAttribute('aria-hidden', 'false')
     html.classList.add('is-clipped--image-lightbox')
+    if (lightboxImage.complete) {
+      animateLightboxImage(img)
+    } else {
+      lightboxImage.addEventListener('load', function onLoad () {
+        lightboxImage.removeEventListener('load', onLoad)
+        if (lightbox.classList.contains('is-active')) animateLightboxImage(img)
+      })
+    }
   }
 
   function closeLightbox () {
+    var sourceImage = activeSourceImage
     lightbox.classList.remove('is-active')
     lightbox.setAttribute('aria-hidden', 'true')
     html.classList.remove('is-clipped--image-lightbox')
-    lightboxImage.removeAttribute('src')
+    closeTimer = window.setTimeout(function () {
+      if (!lightbox.classList.contains('is-active')) {
+        lightboxImage.removeAttribute('src')
+        lightboxImage.style.transform = ''
+        lightboxImage.style.transition = ''
+      }
+    }, animationDuration)
+    if (sourceImage) animateLightboxImage(sourceImage, true)
+  }
+
+  function animateLightboxImage (img, isClosing) {
+    window.requestAnimationFrame(function () {
+      var sourceRect = img.getBoundingClientRect()
+      var targetRect = lightboxImage.getBoundingClientRect()
+      var transform = getTransformFromRects(sourceRect, targetRect)
+
+      lightboxImage.style.transition = 'none'
+      lightboxImage.style.transform = isClosing ? 'translate(0, 0) scale(1)' : transform
+      lightboxImage.getBoundingClientRect()
+
+      window.requestAnimationFrame(function () {
+        lightboxImage.style.transition = 'transform ' + animationDuration + 'ms cubic-bezier(0.22, 1, 0.36, 1)'
+        lightboxImage.style.transform = isClosing ? transform : 'translate(0, 0) scale(1)'
+      })
+    })
+  }
+
+  function getTransformFromRects (fromRect, toRect) {
+    if (!toRect.width || !toRect.height) return 'translate(0, 0) scale(1)'
+
+    var translateX = fromRect.left + fromRect.width / 2 - (toRect.left + toRect.width / 2)
+    var translateY = fromRect.top + fromRect.height / 2 - (toRect.top + toRect.height / 2)
+    var scaleX = fromRect.width / toRect.width
+    var scaleY = fromRect.height / toRect.height
+
+    return (
+      'translate(' + translateX + 'px, ' + translateY + 'px) ' +
+      'scale(' + scaleX + ', ' + scaleY + ')'
+    )
   }
 })()

--- a/src/js/07-image-lightbox.js
+++ b/src/js/07-image-lightbox.js
@@ -1,0 +1,52 @@
+;(function () {
+  'use strict'
+
+  var article = document.querySelector('article.doc')
+  if (!article) return
+
+  var images = [].slice.call(article.querySelectorAll('.imageblock img, .image > img, .image a > img'))
+    .filter(function (img, index, self) {
+      return (img.currentSrc || img.src) && self.indexOf(img) === index
+    })
+  if (!images.length) return
+
+  var html = document.documentElement
+  var lightbox = document.createElement('div')
+  lightbox.className = 'image-lightbox'
+  lightbox.setAttribute('aria-hidden', 'true')
+
+  var lightboxImage = document.createElement('img')
+  lightboxImage.alt = ''
+  lightbox.appendChild(lightboxImage)
+  document.body.appendChild(lightbox)
+
+  images.forEach(function (img) {
+    img.addEventListener('click', function (e) {
+      e.preventDefault()
+      openLightbox(img)
+    })
+  })
+
+  lightbox.addEventListener('click', function (e) {
+    if (e.target === lightbox) closeLightbox()
+  })
+
+  window.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && lightbox.classList.contains('is-active')) closeLightbox()
+  })
+
+  function openLightbox (img) {
+    lightboxImage.src = img.currentSrc || img.src
+    lightboxImage.alt = img.alt || ''
+    lightbox.classList.add('is-active')
+    lightbox.setAttribute('aria-hidden', 'false')
+    html.classList.add('is-clipped--image-lightbox')
+  }
+
+  function closeLightbox () {
+    lightbox.classList.remove('is-active')
+    lightbox.setAttribute('aria-hidden', 'true')
+    html.classList.remove('is-clipped--image-lightbox')
+    lightboxImage.removeAttribute('src')
+  }
+})()


### PR DESCRIPTION
This PR adds an image lightbox to documentation pages.

Images can now be opened in an overlay for easier inspection without leaving the current page. The lightbox supports closing by clicking the backdrop or pressing Escape, and uses a light blurred backdrop to keep the page context visible.

<img width="1892" height="1956" alt="image" src="https://github.com/user-attachments/assets/6b39fb25-d99a-4728-a8d0-c6816ef33edf" />
