### PR TITLE
footer: Fix document footer layout

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1,16 +1,20 @@
 .doc {
   color: var(--doc-font-color);
+  display: flex;
+  flex-direction: column;
   font-size: var(--doc-font-size);
   hyphens: auto;
   line-height: var(--doc-line-height);
   margin: var(--doc-margin);
   max-width: var(--doc-max-width);
-  padding: 0 1rem 4rem;
+  min-height: calc(var(--body-min-height) - var(--toolbar-height));
+  padding: 0 1rem;
 }
 
 @media screen and (min-width: 1024px) {
   .doc {
     flex: auto;
+    flex-direction: column;
     font-size: var(--doc-font-size--desktop);
     margin: var(--doc-margin--desktop);
     max-width: var(--doc-max-width--desktop);

--- a/src/css/footer.css
+++ b/src/css/footer.css
@@ -1,13 +1,22 @@
-footer.footer {
-  background-color: var(--footer-background);
+article.doc > footer.footer {
+  background: transparent;
   color: var(--footer-font-color);
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--footer-line-height);
-  padding: 1.5rem;
+  margin-top: auto;
+  padding: 2rem 1rem 1rem;
+  text-align: center;
+}
+
+article.doc > footer.footer::before {
+  border-top: 1px solid var(--toolbar-border-color);
+  content: "";
+  display: block;
+  margin-bottom: 1rem;
 }
 
 .footer p {
-  margin: 0.5rem 0;
+  margin: 0;
 }
 
 .footer a {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -20,6 +20,7 @@ body.-toc aside.toc.sidebar {
 
   main > .content {
     display: flex;
+    min-height: calc(var(--body-min-height) - var(--toolbar-height));
   }
 
   aside.toc.embedded {

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -6,6 +6,6 @@
   <body class="article{{#with (or page.attributes.role page.role)}} {{{this}}}{{/with}}">
 {{> header}}
 {{> body}}
-{{> footer}}
+{{> footer-scripts}}
   </body>
 </html>

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -4,4 +4,5 @@
 {{/with}}
 {{{page.contents}}}
 {{> pagination}}
+{{> footer-content}}
 </article>

--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -1,11 +1,3 @@
 <footer class="footer">
-  <div class="container">
-    <div>
-      <p>This page was built using the Antora default UI.</p>
-      <p>The source code for this UI is licensed under the terms of the MPL-2.0 license.</p>
-    </div>
-    <div style="width: 100%; text-align: right; margin-top: 0.5rem;">
-      <img src="{{{uiRootPath}}}/img/sc-logo.png" alt="Logo" style="height: 3rem;">
-    </div>
-  </div>
+  <p>Copyright {{year}}, SpaceCubics Inc.</p>
 </footer>


### PR DESCRIPTION
The existing page-wide footer could affect the navigation layout when it was displayed. For this documentation UI, only a minimal footer is needed.

Place the footer inside the article flow and simplify it to a copyright line so it does not disturb the navigation or TOC layout.

- before
<img width="1876" height="1940" alt="image" src="https://github.com/user-attachments/assets/19e3e623-4241-4408-a51a-f08c3b67408c" />

- after
<img width="1885" height="1953" alt="image" src="https://github.com/user-attachments/assets/5d270360-9fc3-48a9-9fa3-9c2140d35861" />
