### PR TITLE
Fix toolbar shift while image lightbox is open

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -9,6 +9,7 @@ html {
   font-size: var(--body-font-size);
   height: 100%;
   scroll-behavior: smooth;
+  scrollbar-gutter: stable;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -547,8 +547,7 @@
   transform-origin: center center;
 }
 
-html.is-clipped--image-lightbox,
-html.is-clipped--image-lightbox body {
+html.is-clipped--image-lightbox {
   overflow: hidden;
 }
 


### PR DESCRIPTION
The image lightbox was locking both html and body with overflow: hidden.
Because the toolbar uses position: sticky, making body a non-visible overflow container changed its sticky containing block only while the lightbox was active, which made the toolbar appear shifted.

Opening the lightbox also removed the page scrollbar, which could trigger a layout recalculation in the toolbar area.

Limit the scroll lock to html and reserve scrollbar space with scrollbar-gutter: stable so the toolbar keeps the same sticky context and width while the lightbox is open.

- before
<img width="1377" height="1457" alt="image" src="https://github.com/user-attachments/assets/b0272a34-4f91-4911-9c59-97db8632c759" />

- after
<img width="1379" height="1306" alt="image" src="https://github.com/user-attachments/assets/850ce2af-ee1d-4e44-9570-d0cc7737069c" />
