### PR TITLE
Add figure and table links to the page TOC

### DIFF
--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -4,6 +4,9 @@
 
 .toc.sidebar .toc-menu {
   margin-right: 0.75rem;
+  max-height: var(--toc-height);
+  overflow-y: auto;
+  overscroll-behavior: none;
   position: sticky;
   top: var(--toc-top);
 }
@@ -17,13 +20,6 @@
   padding-bottom: 0.25rem;
 }
 
-.toc.sidebar .toc-menu h3 {
-  display: flex;
-  flex-direction: column;
-  height: 2.5rem;
-  justify-content: flex-end;
-}
-
 .toc .toc-menu ul {
   font-size: calc(15 / var(--rem-base) * 1rem);
   line-height: var(--toc-line-height);
@@ -32,21 +28,23 @@
   padding: 0;
 }
 
-.toc.sidebar .toc-menu ul {
-  max-height: var(--toc-height);
-  overflow-y: auto;
-  overscroll-behavior: none;
-}
-
 @supports (scrollbar-width: none) {
-  .toc.sidebar .toc-menu ul {
+  .toc.sidebar .toc-menu {
     scrollbar-width: none;
   }
 }
 
-.toc .toc-menu ul::-webkit-scrollbar {
+.toc .toc-menu::-webkit-scrollbar {
   width: 0;
   height: 0;
+}
+
+.toc .toc-section + .toc-section {
+  margin-top: 0.9rem;
+}
+
+.toc .toc-section:first-child h3 {
+  padding-top: 2rem;
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/js/02-on-this-page.js
+++ b/src/js/02-on-this-page.js
@@ -22,11 +22,13 @@
     headingsSelector.push(headingSelector.join('>'))
   }
   var headings = find(headingsSelector.join(','), article.parentNode)
-  if (!headings.length) return sidebar.parentNode.removeChild(sidebar)
+  var figures = collectCaptionEntries(article, '.imageblock > .title, .videoblock > .title', 'figure')
+  var tables = collectCaptionEntries(article, 'table.tableblock > caption', 'table')
+  if (!headings.length && !figures.length && !tables.length) return sidebar.parentNode.removeChild(sidebar)
 
   var lastActiveFragment
   var links = {}
-  var list = headings.reduce(function (accum, heading) {
+  var contentsList = headings.length ? headings.reduce(function (accum, heading) {
     var link = document.createElement('a')
     link.textContent = heading.textContent
     links[(link.href = '#' + heading.id)] = link
@@ -35,15 +37,17 @@
     listItem.appendChild(link)
     accum.appendChild(listItem)
     return accum
-  }, document.createElement('ul'))
+  }, document.createElement('ul')) : undefined
 
   var menu = sidebar.querySelector('.toc-menu')
   if (!menu) (menu = document.createElement('div')).className = 'toc-menu'
 
-  var title = document.createElement('h3')
-  title.textContent = sidebar.dataset.title || 'Contents'
-  menu.appendChild(title)
-  menu.appendChild(list)
+  var sections = document.createElement('div')
+  sections.className = 'toc-sections'
+  if (contentsList) sections.appendChild(createSection(sidebar.dataset.title || 'Contents', contentsList))
+  if (figures.length) sections.appendChild(createSection('Figures', createCaptionList(figures)))
+  if (tables.length) sections.appendChild(createSection('Tables', createCaptionList(tables)))
+  menu.appendChild(sections)
 
   var startOfContent = !document.getElementById('toc') && article.querySelector('h1.page ~ :not(.is-before-toc)')
   if (startOfContent) {
@@ -75,7 +79,9 @@
           links[lastActiveFragment.shift()].classList.remove('is-active')
         }
       })
-      list.scrollTop = list.scrollHeight - list.offsetHeight
+      if (contentsList && contentsList.scrollHeight > contentsList.offsetHeight) {
+        contentsList.scrollTop = contentsList.scrollHeight - contentsList.offsetHeight
+      }
       lastActiveFragment = activeFragments.length > 1 ? activeFragments : activeFragments[0]
       return
     }
@@ -95,8 +101,8 @@
       if (lastActiveFragment) links[lastActiveFragment].classList.remove('is-active')
       var activeLink = links[activeFragment]
       activeLink.classList.add('is-active')
-      if (list.scrollHeight > list.offsetHeight) {
-        list.scrollTop = Math.max(0, activeLink.offsetTop + activeLink.offsetHeight - list.offsetHeight)
+      if (menu.scrollHeight > menu.offsetHeight) {
+        menu.scrollTop = Math.max(0, activeLink.offsetTop + activeLink.offsetHeight - menu.offsetHeight)
       }
       lastActiveFragment = activeFragment
     } else if (lastActiveFragment) {
@@ -107,6 +113,38 @@
 
   function find (selector, from) {
     return [].slice.call((from || document).querySelectorAll(selector))
+  }
+
+  function collectCaptionEntries (root, selector, prefix) {
+    return find(selector, root).map(function (caption, index) {
+      var target = caption.parentNode
+      if (!target.id) target.id = prefix + '-' + (index + 1)
+      return { id: target.id, text: caption.textContent.trim() }
+    }).filter(function (entry) {
+      return entry.text
+    })
+  }
+
+  function createCaptionList (entries) {
+    return entries.reduce(function (accum, entry) {
+      var link = document.createElement('a')
+      link.textContent = entry.text
+      link.href = '#' + entry.id
+      var listItem = document.createElement('li')
+      listItem.appendChild(link)
+      accum.appendChild(listItem)
+      return accum
+    }, document.createElement('ul'))
+  }
+
+  function createSection (label, list) {
+    var section = document.createElement('div')
+    section.className = 'toc-section'
+    var sectionTitle = document.createElement('h3')
+    sectionTitle.textContent = label
+    section.appendChild(sectionTitle)
+    section.appendChild(list)
+    return section
   }
 
   function getNumericStyleVal (el, prop) {


### PR DESCRIPTION
Extend the on-this-page sidebar to include caption links for figures and tables. These entries are generated only for images and tables that have titles in the AsciiDoc source, so untitled images and tables are not shown in the TOC.

<img width="1612" height="1481" alt="image" src="https://github.com/user-attachments/assets/50290f51-8866-406a-81c4-4054c76fc88f" />

https://github.com/user-attachments/assets/7ea25fac-9681-41ed-83b2-c467bd751f0b

