### PR TITLE
Add responsive table scrolling

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -254,8 +254,22 @@
   margin-top: 1.5rem;
 }
 
+.doc .tablecontainer {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  position: relative;
+  -webkit-overflow-scrolling: touch;
+}
+
 .doc table.tableblock {
   font-size: calc(15 / var(--rem-base) * 1rem);
+}
+
+.doc .tablecontainer > table.tableblock {
+  min-width: 100%;
+  width: max-content;
 }
 
 .doc p.tableblock + p.tableblock {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -263,6 +263,34 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.doc .tablecontainer.is-scrollable::after {
+  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: 999px;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.12);
+  color: var(--doc-font-color);
+  content: "Scroll horizontally";
+  font-size: calc(12 / var(--rem-base) * 1rem);
+  font-style: normal;
+  font-weight: var(--body-font-weight-bold);
+  letter-spacing: 0.01em;
+  left: 50%;
+  padding: 0.375rem 0.75rem;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: opacity 180ms ease, transform 180ms ease;
+  white-space: nowrap;
+  z-index: 3;
+}
+
+.doc .tablecontainer.is-scrolled::after {
+  opacity: 0;
+  transform: translate(-50%, calc(-50% + 0.5rem));
+}
+
 .doc table.tableblock {
   font-size: calc(15 / var(--rem-base) * 1rem);
 }

--- a/src/js/08-responsive-tables.js
+++ b/src/js/08-responsive-tables.js
@@ -1,0 +1,24 @@
+;(function () {
+  'use strict'
+
+  var article = document.querySelector('article.doc')
+  if (!article) return
+
+  var tables = [].slice.call(article.querySelectorAll('table.tableblock'))
+  if (!tables.length) return
+
+  tables.forEach(function (table) {
+    ensureTableContainer(table)
+  })
+
+  function ensureTableContainer (table) {
+    var container = table.closest('.tablecontainer')
+    if (container) return container
+
+    container = document.createElement('div')
+    container.className = 'tablecontainer'
+    table.parentNode.insertBefore(container, table)
+    container.appendChild(table)
+    return container
+  }
+})()

--- a/src/js/08-responsive-tables.js
+++ b/src/js/08-responsive-tables.js
@@ -7,9 +7,21 @@
   var tables = [].slice.call(article.querySelectorAll('table.tableblock'))
   if (!tables.length) return
 
+  var containers = new Set()
+
   tables.forEach(function (table) {
-    ensureTableContainer(table)
+    var container = ensureTableContainer(table)
+
+    if (!containers.has(container)) {
+      containers.add(container)
+      container.addEventListener('scroll', function () {
+        updateScrollableState(container)
+      })
+    }
   })
+
+  window.addEventListener('resize', updateScrollableStates)
+  updateScrollableStates()
 
   function ensureTableContainer (table) {
     var container = table.closest('.tablecontainer')
@@ -20,5 +32,23 @@
     table.parentNode.insertBefore(container, table)
     container.appendChild(table)
     return container
+  }
+
+  function updateScrollableStates () {
+    containers.forEach(function (container) {
+      updateScrollableState(container)
+    })
+  }
+
+  function updateScrollableState (container) {
+    var isScrollable = container.scrollWidth - container.clientWidth > 1
+    var hasScrolled = container.scrollLeft > 1
+    var hasSeenScrollHint = container.classList.contains('has-seen-scroll-hint')
+    if (isScrollable && hasScrolled && !hasSeenScrollHint) {
+      container.classList.add('has-seen-scroll-hint')
+      hasSeenScrollHint = true
+    }
+    container.classList.toggle('is-scrollable', isScrollable && !hasSeenScrollHint)
+    container.classList.toggle('is-scrolled', isScrollable && hasScrolled)
   }
 })()


### PR DESCRIPTION
Wide documentation tables can overflow the article column on narrow screens or when they contain long content.

Wrap table blocks in a scrollable container, keep the table width based on its content, and show a small horizontal scroll hint only when scrolling is needed.
The hint is hidden after the user scrolls the table once to avoid repeatedly covering the table content.

- before
<img width="1296" height="664" alt="image" src="https://github.com/user-attachments/assets/3d2045f3-602c-48e6-b8ef-149416fc2d37" />

- after
<img width="1312" height="687" alt="image" src="https://github.com/user-attachments/assets/cc846d46-edd5-4701-823b-b384cff48309" />

https://github.com/user-attachments/assets/ae2170fa-2890-417b-b126-9702c4513add

