### PR TITLE
Prioritize content width over the side TOC

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -28,13 +28,27 @@ body.-toc aside.toc.sidebar {
   }
 
   aside.toc.sidebar {
-    flex: 0 0 var(--toc-width);
+    flex: 0 1 var(--toc-width);
+    max-width: var(--toc-width--wide);
+    min-width: var(--toc-width--narrow);
     order: 1;
   }
 }
 
 @media screen and (min-width: 1216px) {
   aside.toc.sidebar {
-    flex-basis: var(--toc-width--widescreen);
+    flex-basis: var(--toc-width--stacked);
+  }
+}
+
+@media screen and (min-width: 1024px) and (max-width: 1279.5px) {
+  main > .content {
+    display: block;
+  }
+
+  aside.toc.sidebar {
+    margin: 1rem 2rem 0;
+    max-width: none;
+    min-width: 0;
   }
 }

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -96,3 +96,14 @@
 .sidebar.toc .toc-menu a:focus {
   background: var(--panel-background);
 }
+
+@media screen and (min-width: 1024px) and (max-width: 1279.5px) {
+  .toc.sidebar .toc-menu {
+    margin-right: 0;
+    position: static;
+  }
+
+  .toc.sidebar .toc-menu ul {
+    max-height: none;
+  }
+}

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -140,6 +140,9 @@
   --toc-top: calc(var(--body-top) + var(--toolbar-height));
   --toc-height: calc(100vh - var(--toc-top) - 2.5rem);
   --toc-width: calc(162 / var(--rem-base) * 1rem);
+  --toc-width--narrow: calc(140 / var(--rem-base) * 1rem);
+  --toc-width--wide: calc(240 / var(--rem-base) * 1rem);
+  --toc-width--stacked: calc(288 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(576 / var(--rem-base) * 1rem);
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
   --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);


### PR DESCRIPTION
When the viewport is narrower than expected while the TOC is shown in the side column, the current layout gives priority to keeping the TOC visible. As a result, the document content can become narrower than intended.

Change the layout so the document content keeps its expected width first, and let the TOC shrink or move out of the side-column layout in the affected desktop range.

- before

https://github.com/user-attachments/assets/eea21da5-dde6-4fc3-8563-c6026dbb4b19


- after

https://github.com/user-attachments/assets/b64db1ea-d598-4c25-b9bd-4de1cf869ff1

