### PR TITLE
fix: Prevent TOC from appearing above the title

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -46,9 +46,11 @@ body.-toc aside.toc.sidebar {
     display: block;
   }
 
+  aside.toc.embedded {
+    display: block;
+  }
+
   aside.toc.sidebar {
-    margin: 1rem 2rem 0;
-    max-width: none;
-    min-width: 0;
+    display: none;
   }
 }

--- a/src/css/toc.css
+++ b/src/css/toc.css
@@ -94,14 +94,3 @@
 .sidebar.toc .toc-menu a:focus {
   background: var(--panel-background);
 }
-
-@media screen and (min-width: 1024px) and (max-width: 1279.5px) {
-  .toc.sidebar .toc-menu {
-    margin-right: 0;
-    position: static;
-  }
-
-  .toc.sidebar .toc-menu ul {
-    max-height: none;
-  }
-}


### PR DESCRIPTION
On medium-width layouts, the sidebar TOC could be laid out above the page title instead of behaving like a sidebar. Use the embedded TOC for this width range and hide the sidebar TOC so the page title remains the first document content.

Remove the medium-width sidebar TOC overrides because the sidebar TOC is no longer shown in this range.

- before
<img width="1185" height="814" alt="image" src="https://github.com/user-attachments/assets/c8d81b10-cc0e-4889-8042-357749c325a4" />

- after
<img width="1189" height="778" alt="image" src="https://github.com/user-attachments/assets/e4c7bcff-b49f-47eb-a299-2db513a216e0" />
