### PR TITLE
Refine article background layout

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,3 +1,13 @@
+.article {
+  background: var(--color-smoke-30);
+}
+
+.content-frame {
+  background: var(--color-white);
+  max-width: 100%;
+  width: 100%;
+}
+
 body.-toc aside.toc.sidebar {
   display: none;
 }
@@ -7,9 +17,17 @@ body.-toc aside.toc.sidebar {
     display: none;
   }
 
-  main > .content {
+  .content-frame > .content {
     overflow-x: auto;
   }
+}
+
+.article-panel {
+  min-width: 0;
+}
+
+aside.toc.embedded {
+  background: var(--color-white);
 }
 
 @media screen and (min-width: 1024px) {
@@ -18,7 +36,7 @@ body.-toc aside.toc.sidebar {
     min-width: 0; /* min-width: 0 required for flexbox to constrain overflowing elements */
   }
 
-  main > .content {
+  .content-frame > .content {
     display: flex;
     min-height: calc(var(--body-min-height) - var(--toolbar-height));
   }
@@ -33,6 +51,15 @@ body.-toc aside.toc.sidebar {
     min-width: var(--toc-width--narrow);
     order: 1;
   }
+
+  .article-panel {
+    display: flex;
+    flex: 0 1 calc(var(--doc-max-width--desktop) + 4rem);
+    flex-direction: column;
+    max-width: calc(var(--doc-max-width--desktop) + 4rem);
+    min-width: 0;
+    width: 100%;
+  }
 }
 
 @media screen and (min-width: 1216px) {
@@ -42,8 +69,12 @@ body.-toc aside.toc.sidebar {
 }
 
 @media screen and (min-width: 1024px) and (max-width: 1279.5px) {
-  main > .content {
+  .content-frame > .content {
     display: block;
+  }
+
+  .article-panel {
+    max-width: none;
   }
 
   aside.toc.embedded {
@@ -52,5 +83,11 @@ body.-toc aside.toc.sidebar {
 
   aside.toc.sidebar {
     display: none;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .content-frame {
+    width: calc(var(--doc-max-width--desktop) + 4rem + var(--toc-width--stacked));
   }
 }

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -3,12 +3,15 @@
   align-items: center;
   background-color: var(--toolbar-background);
   box-shadow: 0 1px 0 var(--toolbar-border-color);
+  box-sizing: border-box;
   display: flex;
   font-size: calc(15 / var(--rem-base) * 1rem);
   height: var(--toolbar-height);
   justify-content: flex-start;
+  margin: 0;
   position: sticky;
   top: 0;
+  width: 100%;
   z-index: var(--z-index-toolbar);
 }
 

--- a/src/partials/main.hbs
+++ b/src/partials/main.hbs
@@ -1,11 +1,15 @@
 <main class="article">
-{{> toolbar}}
-  <div class="content">
+  <div class="content-frame">
+    {{> toolbar}}
+    <div class="content">
 {{#if (eq page.layout '404')}}
 {{> article-404}}
 {{else}}
 {{> toc}}
+      <div class="article-panel">
 {{> article}}
+      </div>
 {{/if}}
+    </div>
   </div>
 </main>


### PR DESCRIPTION
Wrap the toolbar, article content, and page TOC in a shared content frame so the document surface stays white while the outer article area can use a subtle background color.

This makes the main reading area visually distinct from the surrounding page space without changing the article content width. Also constrain the toolbar to the content frame so it remains aligned with the document surface.


https://github.com/user-attachments/assets/7fd863ea-8dfe-4105-9c06-a108f340bc6c

