### PR TITLE
Add MathJax support to head metadata

### DIFF
--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,1 +1,17 @@
-    {{!-- Add additional meta tags here --}}
+    <script>
+      window.MathJax = {
+        tex: {
+          inlineMath: [
+            ['\\(', '\\)']
+          ],
+          displayMath: [
+            ['\\[', '\\]']
+          ],
+          processEscapes: true,
+        },
+        options: {
+          processHtmlClass: 'stemblock',
+        }
+      }
+    </script>
+    <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>


### PR DESCRIPTION
SC Docs supports MathJax as a UI/rendering feature, not as a content-specific customization. Add the MathJax configuration and script loading to the UI's head-meta partial so MathJax is available consistently across all documentation pages.

This also means documentation repositories no longer need to provide the MathJax setup through supplemental UI files in their Antora playbooks.